### PR TITLE
feat(artifact-keeper): deploy with local 50Gi PVC in default namespace

### DIFF
--- a/kubernetes/apps/database/crunchy-postgres/cluster/postgrescluster.yaml
+++ b/kubernetes/apps/database/crunchy-postgres/cluster/postgrescluster.yaml
@@ -80,6 +80,11 @@ spec:
       options: "SUPERUSER"
       password:
         type: AlphaNumeric
+    - name: artifact-keeper
+      databases:
+        - artifact-keeper
+      password:
+        type: AlphaNumeric
     - name: atuin
       databases:
         - atuin

--- a/kubernetes/apps/default/artifact-keeper/app/configmap.yaml
+++ b/kubernetes/apps/default/artifact-keeper/app/configmap.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: artifact-keeper-caddy
+data:
+  Caddyfile: |
+    {
+      auto_https off
+      admin off
+    }
+
+    (backend_routes) {
+      # API and health endpoints
+      reverse_proxy /api/* localhost:8080
+      reverse_proxy /health localhost:8080
+      reverse_proxy /livez localhost:8080
+      reverse_proxy /readyz localhost:8080
+      reverse_proxy /metrics localhost:8080
+      reverse_proxy /swagger-ui* localhost:8080
+      # OCI / Docker registry
+      reverse_proxy /v2 localhost:8080
+      reverse_proxy /v2/* localhost:8080
+      # Native package format handlers — route directly to backend
+      # so requests avoid the Next.js middleware proxy hop
+      reverse_proxy /maven/* localhost:8080
+      reverse_proxy /npm/* localhost:8080
+      reverse_proxy /pypi/* localhost:8080
+      reverse_proxy /nuget/* localhost:8080
+      reverse_proxy /cargo/* localhost:8080
+      reverse_proxy /gems/* localhost:8080
+      reverse_proxy /go/* localhost:8080
+      reverse_proxy /helm/* localhost:8080
+      reverse_proxy /debian/* localhost:8080
+      reverse_proxy /rpm/* localhost:8080
+      reverse_proxy /alpine/* localhost:8080
+      reverse_proxy /composer/* localhost:8080
+      reverse_proxy /conan/* localhost:8080
+      reverse_proxy /conda/* localhost:8080
+      reverse_proxy /swift/* localhost:8080
+      reverse_proxy /terraform/* localhost:8080
+      reverse_proxy /cocoapods/* localhost:8080
+      reverse_proxy /hex/* localhost:8080
+      reverse_proxy /pub/* localhost:8080
+      reverse_proxy /lfs/* localhost:8080
+      reverse_proxy /ivy/* localhost:8080
+      reverse_proxy /chef/* localhost:8080
+      reverse_proxy /puppet/* localhost:8080
+      reverse_proxy /ansible/* localhost:8080
+      reverse_proxy /cran/* localhost:8080
+      reverse_proxy /huggingface/* localhost:8080
+      reverse_proxy /jetbrains/* localhost:8080
+      reverse_proxy /vscode/* localhost:8080
+      reverse_proxy /proto/* localhost:8080
+      reverse_proxy /incus/* localhost:8080
+      reverse_proxy /ext/* localhost:8080
+    }
+
+    :8000 {
+      import backend_routes
+      reverse_proxy localhost:3000
+    }

--- a/kubernetes/apps/default/artifact-keeper/app/externalsecret.yaml
+++ b/kubernetes/apps/default/artifact-keeper/app/externalsecret.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &secretName artifact-keeper-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *secretName
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        JWT_SECRET: "{{ .JWT_SECRET }}"
+        ADMIN_PASSWORD: "{{ .ADMIN_PASSWORD }}"
+        MEILI_MASTER_KEY: "{{ .MEILI_MASTER_KEY }}"
+        MEILISEARCH_API_KEY: "{{ .MEILI_MASTER_KEY }}"
+  dataFrom:
+    - extract:
+        key: artifact-keeper
+
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &secretName artifact-keeper-db-secret
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: crunchy-pgo-secrets
+  target:
+    name: *secretName
+    template:
+      type: Opaque
+      data:
+        DATABASE_URL: '{{ index . "uri" }}?sslmode=disable'
+  dataFrom:
+    - extract:
+        key: postgres-pguser-artifact-keeper

--- a/kubernetes/apps/default/artifact-keeper/app/helmrelease.yaml
+++ b/kubernetes/apps/default/artifact-keeper/app/helmrelease.yaml
@@ -1,0 +1,201 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app artifact-keeper
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: artifact-keeper
+  interval: 30m
+  values:
+    fullnameOverride: *app
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: {type: RuntimeDefault}
+
+    controllers:
+      artifact-keeper:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: Recreate
+        containers:
+          backend:
+            image:
+              repository: ghcr.io/artifact-keeper/artifact-keeper-backend
+              tag: "1.1.6"
+            env:
+              STORAGE_PATH: /data/storage
+              BACKUP_PATH: /data/backups
+              PLUGINS_DIR: /data/plugins
+              SCAN_WORKSPACE_PATH: /data/scan-workspace
+              RUST_LOG: info,artifact_keeper=info
+              ENVIRONMENT: production
+              CORS_ORIGINS: https://artifacts.pospiech.dev
+              HOST: 0.0.0.0
+              PORT: "8080"
+              MEILISEARCH_URL: http://localhost:7700
+              TRIVY_URL: http://localhost:8090
+              DEPENDENCY_TRACK_ENABLED: "false"
+              ALLOW_HTTP_INTEGRATIONS: "1"
+            envFrom:
+              - secretRef:
+                  name: artifact-keeper-secret
+              - secretRef:
+                  name: artifact-keeper-db-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /livez
+                    port: 8080
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: 8080
+                  initialDelaySeconds: 15
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+          web:
+            image:
+              repository: ghcr.io/artifact-keeper/artifact-keeper-web
+              tag: "1.1.6"
+            env:
+              BACKEND_URL: http://localhost:8080
+              PORT: "3000"
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+          meilisearch:
+            image:
+              repository: docker.io/getmeili/meilisearch
+              tag: v1.12
+            env:
+              MEILI_NO_ANALYTICS: "true"
+              MEILI_ENV: production
+              MEILI_DB_PATH: /data/meilisearch
+              MEILI_HTTP_ADDR: 0.0.0.0:7700
+              MEILI_MASTER_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: artifact-keeper-secret
+                    key: MEILI_MASTER_KEY
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 7700
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 7700
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+          trivy:
+            image:
+              repository: ghcr.io/aquasecurity/trivy
+              tag: "0.69.3"
+            args:
+              - server
+              - --listen
+              - 0.0.0.0:8090
+              - --cache-dir
+              - /data/trivy-cache
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+
+          caddy:
+            image:
+              repository: docker.io/library/caddy
+              tag: 2-alpine
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+
+    service:
+      app:
+        primary: true
+        controller: artifact-keeper
+        ports:
+          http:
+            port: 8000
+
+    route:
+      app:
+        hostnames:
+          - "artifacts.pospiech.dev"
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8000
+
+    persistence:
+      data:
+        existingClaim: *app
+        advancedMounts:
+          artifact-keeper:
+            backend:
+              - path: /data
+            meilisearch:
+              - path: /data
+            trivy:
+              - path: /data
+      caddyfile:
+        type: configMap
+        name: artifact-keeper-caddy
+        advancedMounts:
+          artifact-keeper:
+            caddy:
+              - subPath: Caddyfile
+                path: /etc/caddy/Caddyfile
+                readOnly: true

--- a/kubernetes/apps/default/artifact-keeper/app/kustomization.yaml
+++ b/kubernetes/apps/default/artifact-keeper/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./pvc.yaml
+  - ./configmap.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/default/artifact-keeper/app/ocirepository.yaml
+++ b/kubernetes/apps/default/artifact-keeper/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: artifact-keeper
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/artifact-keeper/app/pvc.yaml
+++ b/kubernetes/apps/default/artifact-keeper/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: artifact-keeper
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/default/artifact-keeper/ks.yaml
+++ b/kubernetes/apps/default/artifact-keeper/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app artifact-keeper
+spec:
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+    - name: crunchy-postgres-operator-cluster
+      namespace: database
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 30m
+  path: ./kubernetes/apps/default/artifact-keeper/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -10,6 +10,7 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./artifact-keeper/ks.yaml
   - ./atuin/ks.yaml
   - ./backlogs/ks.yaml
   - ./bentopdf/ks.yaml


### PR DESCRIPTION
## Summary

Deploy [Artifact Keeper](https://artifactkeeper.com/) `1.1.6` in the `default` namespace via `app-template`.

- Single pod, five containers: `backend`, `web`, `meilisearch`, `trivy`, `caddy`
- Caddy sidecar reproduces upstream [`docker/Caddyfile`](https://github.com/artifact-keeper/artifact-keeper/blob/main/docker/Caddyfile) routing: package-format + API paths → backend, everything else → web UI
- **50 Gi `ceph-block` PVC** mounted at `/data` (subdirs for storage, backups, plugins, scan-workspace, meilisearch, trivy-cache)
- **No volsync backup** — plain `PersistentVolumeClaim` resource
- Two `ExternalSecret`s:
  - `artifact-keeper-secret` — pulls `JWT_SECRET`, `ADMIN_PASSWORD`, `MEILI_MASTER_KEY` from 1Password (vault `Kubernetes`, item `artifact-keeper`); also maps `MEILI_MASTER_KEY` → `MEILISEARCH_API_KEY` for the backend
  - `artifact-keeper-db-secret` — `DATABASE_URL` built from Crunchy `postgres-pguser-artifact-keeper` with `?sslmode=disable`
- Route `artifacts.pospiech.dev` on `envoy-external`
- `DEPENDENCY_TRACK_ENABLED=false`, OpenSCAP skipped; Trivy enabled in server mode with cache at `/data/trivy-cache`
- Adds `artifact-keeper` user + db to the shared Crunchy Postgres cluster

## Test plan

- [ ] Flux reconciles `artifact-keeper` Kustomization without errors
- [ ] Crunchy operator creates user + db; `postgres-pguser-artifact-keeper` secret appears
- [ ] `artifact-keeper-secret` and `artifact-keeper-db-secret` sync from external sources
- [ ] PVC `artifact-keeper` binds on `ceph-block`
- [ ] Pod becomes Ready (all 5 containers)
- [ ] `https://artifacts.pospiech.dev` loads the web UI
- [ ] Admin login works with the `ADMIN_PASSWORD` from 1Password
- [ ] A test artifact upload/download round-trips
- [ ] `kubectl exec ... -c trivy -- trivy --version` reachable from backend via `TRIVY_URL`