### PR TITLE
refactor(artifact-keeper): split into per-service deployments

### DIFF
--- a/kubernetes/apps/default/artifact-keeper/app/configmap.yaml
+++ b/kubernetes/apps/default/artifact-keeper/app/configmap.yaml
@@ -12,51 +12,51 @@ data:
 
     (backend_routes) {
       # API and health endpoints
-      reverse_proxy /api/* localhost:8080
-      reverse_proxy /health localhost:8080
-      reverse_proxy /livez localhost:8080
-      reverse_proxy /readyz localhost:8080
-      reverse_proxy /metrics localhost:8080
-      reverse_proxy /swagger-ui* localhost:8080
+      reverse_proxy /api/* artifact-keeper-backend:8080
+      reverse_proxy /health artifact-keeper-backend:8080
+      reverse_proxy /livez artifact-keeper-backend:8080
+      reverse_proxy /readyz artifact-keeper-backend:8080
+      reverse_proxy /metrics artifact-keeper-backend:8080
+      reverse_proxy /swagger-ui* artifact-keeper-backend:8080
       # OCI / Docker registry
-      reverse_proxy /v2 localhost:8080
-      reverse_proxy /v2/* localhost:8080
+      reverse_proxy /v2 artifact-keeper-backend:8080
+      reverse_proxy /v2/* artifact-keeper-backend:8080
       # Native package format handlers — route directly to backend
       # so requests avoid the Next.js middleware proxy hop
-      reverse_proxy /maven/* localhost:8080
-      reverse_proxy /npm/* localhost:8080
-      reverse_proxy /pypi/* localhost:8080
-      reverse_proxy /nuget/* localhost:8080
-      reverse_proxy /cargo/* localhost:8080
-      reverse_proxy /gems/* localhost:8080
-      reverse_proxy /go/* localhost:8080
-      reverse_proxy /helm/* localhost:8080
-      reverse_proxy /debian/* localhost:8080
-      reverse_proxy /rpm/* localhost:8080
-      reverse_proxy /alpine/* localhost:8080
-      reverse_proxy /composer/* localhost:8080
-      reverse_proxy /conan/* localhost:8080
-      reverse_proxy /conda/* localhost:8080
-      reverse_proxy /swift/* localhost:8080
-      reverse_proxy /terraform/* localhost:8080
-      reverse_proxy /cocoapods/* localhost:8080
-      reverse_proxy /hex/* localhost:8080
-      reverse_proxy /pub/* localhost:8080
-      reverse_proxy /lfs/* localhost:8080
-      reverse_proxy /ivy/* localhost:8080
-      reverse_proxy /chef/* localhost:8080
-      reverse_proxy /puppet/* localhost:8080
-      reverse_proxy /ansible/* localhost:8080
-      reverse_proxy /cran/* localhost:8080
-      reverse_proxy /huggingface/* localhost:8080
-      reverse_proxy /jetbrains/* localhost:8080
-      reverse_proxy /vscode/* localhost:8080
-      reverse_proxy /proto/* localhost:8080
-      reverse_proxy /incus/* localhost:8080
-      reverse_proxy /ext/* localhost:8080
+      reverse_proxy /maven/* artifact-keeper-backend:8080
+      reverse_proxy /npm/* artifact-keeper-backend:8080
+      reverse_proxy /pypi/* artifact-keeper-backend:8080
+      reverse_proxy /nuget/* artifact-keeper-backend:8080
+      reverse_proxy /cargo/* artifact-keeper-backend:8080
+      reverse_proxy /gems/* artifact-keeper-backend:8080
+      reverse_proxy /go/* artifact-keeper-backend:8080
+      reverse_proxy /helm/* artifact-keeper-backend:8080
+      reverse_proxy /debian/* artifact-keeper-backend:8080
+      reverse_proxy /rpm/* artifact-keeper-backend:8080
+      reverse_proxy /alpine/* artifact-keeper-backend:8080
+      reverse_proxy /composer/* artifact-keeper-backend:8080
+      reverse_proxy /conan/* artifact-keeper-backend:8080
+      reverse_proxy /conda/* artifact-keeper-backend:8080
+      reverse_proxy /swift/* artifact-keeper-backend:8080
+      reverse_proxy /terraform/* artifact-keeper-backend:8080
+      reverse_proxy /cocoapods/* artifact-keeper-backend:8080
+      reverse_proxy /hex/* artifact-keeper-backend:8080
+      reverse_proxy /pub/* artifact-keeper-backend:8080
+      reverse_proxy /lfs/* artifact-keeper-backend:8080
+      reverse_proxy /ivy/* artifact-keeper-backend:8080
+      reverse_proxy /chef/* artifact-keeper-backend:8080
+      reverse_proxy /puppet/* artifact-keeper-backend:8080
+      reverse_proxy /ansible/* artifact-keeper-backend:8080
+      reverse_proxy /cran/* artifact-keeper-backend:8080
+      reverse_proxy /huggingface/* artifact-keeper-backend:8080
+      reverse_proxy /jetbrains/* artifact-keeper-backend:8080
+      reverse_proxy /vscode/* artifact-keeper-backend:8080
+      reverse_proxy /proto/* artifact-keeper-backend:8080
+      reverse_proxy /incus/* artifact-keeper-backend:8080
+      reverse_proxy /ext/* artifact-keeper-backend:8080
     }
 
     :8000 {
       import backend_routes
-      reverse_proxy localhost:3000
+      reverse_proxy artifact-keeper-web:3000
     }

--- a/kubernetes/apps/default/artifact-keeper/app/helmrelease.yaml
+++ b/kubernetes/apps/default/artifact-keeper/app/helmrelease.yaml
@@ -18,12 +18,12 @@ spec:
         seccompProfile: {type: RuntimeDefault}
 
     controllers:
-      artifact-keeper:
+      backend:
         annotations:
           reloader.stakater.com/auto: "true"
         strategy: Recreate
         containers:
-          backend:
+          app:
             image:
               repository: ghcr.io/artifact-keeper/artifact-keeper-backend
               tag: "1.1.6"
@@ -37,8 +37,8 @@ spec:
               CORS_ORIGINS: https://artifacts.pospiech.dev
               HOST: 0.0.0.0
               PORT: "8080"
-              MEILISEARCH_URL: http://localhost:7700
-              TRIVY_URL: http://localhost:8090
+              MEILISEARCH_URL: http://artifact-keeper-meilisearch.default.svc.cluster.local:7700
+              TRIVY_URL: http://artifact-keeper-trivy.default.svc.cluster.local:8090
               DEPENDENCY_TRACK_ENABLED: "false"
               ALLOW_HTTP_INTEGRATIONS: "1"
             envFrom:
@@ -76,12 +76,16 @@ spec:
               limits:
                 memory: 1Gi
 
-          web:
+      web:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
             image:
               repository: ghcr.io/artifact-keeper/artifact-keeper-web
-              tag: "1.1.6"
+              tag: "1.1.3"
             env:
-              BACKEND_URL: http://localhost:8080
+              BACKEND_URL: http://artifact-keeper-backend.default.svc.cluster.local:8080
               PORT: "3000"
             resources:
               requests:
@@ -90,7 +94,12 @@ spec:
               limits:
                 memory: 512Mi
 
-          meilisearch:
+      meilisearch:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: Recreate
+        containers:
+          app:
             image:
               repository: docker.io/getmeili/meilisearch
               tag: v1.12
@@ -130,7 +139,12 @@ spec:
               limits:
                 memory: 1Gi
 
-          trivy:
+      trivy:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: Recreate
+        containers:
+          app:
             image:
               repository: ghcr.io/aquasecurity/trivy
               tag: "0.69.3"
@@ -147,7 +161,11 @@ spec:
               limits:
                 memory: 2Gi
 
-          caddy:
+      caddy:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
             image:
               repository: docker.io/library/caddy
               tag: 2-alpine
@@ -160,11 +178,32 @@ spec:
 
     service:
       app:
+        forceRename: artifact-keeper
         primary: true
-        controller: artifact-keeper
+        controller: caddy
         ports:
           http:
             port: 8000
+      backend:
+        controller: backend
+        ports:
+          http:
+            port: 8080
+      web:
+        controller: web
+        ports:
+          http:
+            port: 3000
+      meilisearch:
+        controller: meilisearch
+        ports:
+          http:
+            port: 7700
+      trivy:
+        controller: trivy
+        ports:
+          http:
+            port: 8090
 
     route:
       app:
@@ -183,19 +222,21 @@ spec:
       data:
         existingClaim: *app
         advancedMounts:
-          artifact-keeper:
-            backend:
+          backend:
+            app:
               - path: /data
-            meilisearch:
+          meilisearch:
+            app:
               - path: /data
-            trivy:
+          trivy:
+            app:
               - path: /data
       caddyfile:
         type: configMap
         name: artifact-keeper-caddy
         advancedMounts:
-          artifact-keeper:
-            caddy:
+          caddy:
+            app:
               - subPath: Caddyfile
                 path: /etc/caddy/Caddyfile
                 readOnly: true

--- a/kubernetes/apps/default/artifact-keeper/app/pvc.yaml
+++ b/kubernetes/apps/default/artifact-keeper/app/pvc.yaml
@@ -4,8 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: artifact-keeper
 spec:
-  accessModes: ["ReadWriteOnce"]
+  accessModes: ["ReadWriteMany"]
   resources:
     requests:
       storage: 50Gi
-  storageClassName: ceph-block
+  storageClassName: ceph-filesystem


### PR DESCRIPTION
Follow-up to #766. Splits the single multi-container pod into five independent Deployments and bumps the web image.

## Summary

- **Separate controllers** — `backend`, `web`, `meilisearch`, `trivy`, `caddy` each run in their own Pod. Each has its own Service reachable via cluster DNS (`artifact-keeper-backend`, `-web`, `-meilisearch`, `-trivy`). The primary Service keeps the name `artifact-keeper` (Caddy on `:8000`) and is the Route target.
- **PVC switched to `ceph-filesystem` (RWX)** — keeping a single 50 Gi PVC shared across `backend`, `meilisearch`, and `trivy`. Required because `scan-workspace` must be readable by both backend (writes artifacts) and trivy (reads them). Same pattern as gitea's 100 Gi RWX volume.
- **Inter-service URLs** now use service DNS instead of `localhost`:
  - `BACKEND_URL=http://artifact-keeper-backend.default.svc.cluster.local:8080`
  - `MEILISEARCH_URL=http://artifact-keeper-meilisearch.default.svc.cluster.local:7700`
  - `TRIVY_URL=http://artifact-keeper-trivy.default.svc.cluster.local:8090`
  - Caddyfile upstreams updated to `artifact-keeper-backend:8080` and `artifact-keeper-web:3000`.
- **`artifact-keeper-web` bumped to `1.1.3`** (its latest published tag). `artifact-keeper-backend` stays on `1.1.6`.

## Trade-offs

- RWX on ceph-filesystem is slightly slower than ceph-block RWO for the artifact storage path, but the isolation and independent-scaling benefits outweigh that here.
- On first reconcile, the existing RWO PVC will need to be recreated as RWX. Flux will delete the old PVC (contents lost) and create the new one. That's acceptable since nothing has been uploaded yet — **confirm this before merging if you've already pushed artifacts.**

## Test plan

- [ ] Flux reconciles without errors; five Deployments come up (`backend`, `web`, `meilisearch`, `trivy`, `caddy`)
- [ ] PVC `artifact-keeper` binds on `ceph-filesystem` with 50 Gi
- [ ] All five Pods reach Ready
- [ ] `kubectl get svc -n default -l app.kubernetes.io/instance=artifact-keeper` shows 5 services
- [ ] `https://artifacts.pospiech.dev/` loads the web UI
- [ ] Admin login works
- [ ] `/v2/` responds from the registry backend (test with `docker login artifacts.pospiech.dev`)
- [ ] Upload + scan flow exercises the backend → trivy path and scan-workspace sharing