### PR TITLE
fix(artifact-keeper): trust gateway X-Forwarded-Proto so docker push works

### DIFF
--- a/kubernetes/apps/default/artifact-keeper/app/configmap.yaml
+++ b/kubernetes/apps/default/artifact-keeper/app/configmap.yaml
@@ -6,8 +6,17 @@ metadata:
 data:
   Caddyfile: |
     {
-      auto_https off
+      auto_https disable_redirects
       admin off
+      servers {
+        # TLS is terminated upstream at the Envoy Gateway. Trust the
+        # X-Forwarded-* headers it sets (scheme, host, client IP) so the
+        # backend builds correct https:// realm URLs in the Docker
+        # registry WWW-Authenticate challenge. Without this, Caddy
+        # overwrites X-Forwarded-Proto with "http" (the scheme it sees
+        # on :8000) and docker push/pull fails with auth errors.
+        trusted_proxies static private_ranges
+      }
     }
 
     (backend_routes) {


### PR DESCRIPTION
## The bug

\`docker push\` and \`docker pull\` against \`artifacts.pospiech.dev\` failed with 401s.

Root cause: the backend ([\`oci_v2.rs:65\`](https://github.com/artifact-keeper/artifact-keeper/blob/main/backend/src/api/handlers/oci_v2.rs#L65)) builds the Bearer realm URL in the registry \`WWW-Authenticate\` challenge from \`X-Forwarded-Proto\` via [\`proxy_helpers::request_base_url\`](https://github.com/artifact-keeper/artifact-keeper/blob/main/backend/src/api/handlers/proxy_helpers.rs#L33) — defaulting to \`http\` when the header is missing.

TLS is terminated upstream at the Envoy Gateway. Envoy sets \`X-Forwarded-Proto: https\` correctly, but Caddy (which has no \`trusted_proxies\` configured by default) was overwriting it with \`http\` because it only sees plain HTTP on its own \`:8000\` listener. The backend therefore emitted:

\`\`\`
Www-Authenticate: Bearer realm=\"http://artifacts.pospiech.dev/v2/token\",service=\"artifact-keeper\"
\`\`\`

Docker clients would not complete the token fetch against an \`http://\` realm behind an HTTPS endpoint and the push failed.

## The fix

Add \`trusted_proxies static private_ranges\` to Caddy's global \`servers\` block. Caddy now trusts the \`X-Forwarded-*\` headers set by the gateway (which sits in a private IP range) instead of overwriting them.

Kept the rest of the Caddyfile **byte-for-byte aligned with the upstream [\`docker/Caddyfile\`](https://github.com/artifact-keeper/artifact-keeper/blob/main/docker/Caddyfile)** (same \`backend_routes\` snippet, same per-path \`reverse_proxy\` directives, same ordering) so future upstream changes can be diffed and merged cleanly. The only structural deviation is the single global-options \`servers\` block — a requirement of our deployment topology, not something upstream would carry.

The reloader annotation on the \`caddy\` controller will restart the pod when Flux applies the ConfigMap.

## Test plan

- [ ] Flux applies the ConfigMap and Caddy pod restarts via reloader
- [ ] \`curl -sI https://artifacts.pospiech.dev/v2/ | grep -i www-auth\` returns a \`realm=\"https://...\"\` URL (not \`http://\`)
- [ ] \`docker login artifacts.pospiech.dev\` succeeds
- [ ] \`docker push artifacts.pospiech.dev/<repo>/<image>:<tag>\` completes
- [ ] \`docker pull\` round-trips