### PR TITLE
fix(artifact-keeper): bump backend to 1.1.8 to fix docker push 401 loop

### DIFF
--- a/kubernetes/apps/default/artifact-keeper/app/helmrelease.yaml
+++ b/kubernetes/apps/default/artifact-keeper/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/artifact-keeper/artifact-keeper-backend
-              tag: "1.1.6"
+              tag: "1.1.8"
             env:
               STORAGE_PATH: /data/storage
               BACKUP_PATH: /data/backups


### PR DESCRIPTION
## Root cause (finally found it)

Docker push against \`artifacts.pospiech.dev/poetica:*\` looped on 401 even with valid credentials. \`crane\` worked fine against the same endpoint with the same admin password — which told us the server and credentials were correct but something about the **Docker client auth flow specifically** was broken.

Upstream fix [#821 / \`acf47dd\`](https://github.com/artifact-keeper/artifact-keeper/commit/acf47dd3e602808584c21141d040b860930dd7a0), shipped in **v1.1.8**, describes the exact symptom we were hitting:

> Docker/OCI push fails with a 401 loop because the \`WWW-Authenticate\` challenge returned by blob and manifest endpoints omits the \`scope\` parameter. Without scope, Docker clients cannot properly cache the token returned by \`/v2/token\`, so they never attach it to subsequent blob HEAD requests, causing repeated 401 responses.

\`crane\` doesn't care — it does its own token bookkeeping. Docker relies on the scoped challenge to associate the returned JWT with the repo it was meant for and never sends it back. Confirmed in our backend logs:

\`\`\`
GET  /v2/token?account=admin&client_id=docker&… → 200  (token issued)
HEAD /v2/poetica/blobs/<digest>                 → 401  (token not attached)
HEAD /v2/poetica/blobs/<digest>                 → 401  (retry, still no token)
…
\`\`\`

Also confirmed with curl that v1.1.6 \`/v2/\*/blobs/\*\` returns:

\`\`\`
www-authenticate: Bearer realm=\"https://artifacts.pospiech.dev/v2/token\",service=\"artifact-keeper\"
\`\`\`

— no \`scope=\`. v1.1.8 adds it.

## The fix

Single-line backend image bump: \`1.1.6\` → \`1.1.8\`. Web stays at \`1.1.3\` (its latest published tag). No config changes needed — v1.1.8 is a backend-only fix and the upstream change is additive.

## Test plan

- [ ] Flux reconciles and backend pod rolls to 1.1.8
- [ ] Confirm new challenge format with curl:
      \`curl -sI -X HEAD https://artifacts.pospiech.dev/v2/poetica/blobs/sha256:deadbeef… | grep -i www-auth\`
      → expect \`realm=\"…/v2/token\",service=\"artifact-keeper\",scope=\"repository:poetica:pull\"\`
- [ ] \`docker push artifacts.pospiech.dev/poetica:ci-test\` from local workstation completes
- [ ] CI pipeline push against \`artifacts.pospiech.dev/poetica/<image>\` succeeds
- [ ] Existing \`crane\` push still works (no regression)