### PR TITLE
revert: restore poetica-amd64 runner image pin to registry.pospiech.dev

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/poetica-amd64/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/poetica-amd64/helmrelease.yaml
@@ -56,7 +56,7 @@ spec:
                 name: docker-storage
         containers:
           - name: runner
-            image: ghcr.io/home-operations/actions-runner:2.334.0@sha256:95d91d7f8d241e319ef2f4fec08f417aa1606b96fbb327643f75c303acd30002
+            image: registry.pospiech.dev/gh-runners/poetica:rolling@sha256:3e10598cc4ee8d2c87b098f3ca8599a9b697bacbfced45d74d4339caaa538c70
             command:
               - "/home/runner/run.sh"
             env:


### PR DESCRIPTION
## Summary

Reverts the temporary fallback applied in e79c7c9 that swapped the
`poetica-amd64` runner image from `registry.pospiech.dev/gh-runners/poetica:rolling`
to `ghcr.io/home-operations/actions-runner`.

## When to merge

Merge once `registry.pospiech.dev` docker login is reliably working:

- Envoy Gateway has been bumped to **v1.8** (ships Envoy 1.38), which fixes
  the HTTP/1.1 upstream connection-pool race (`envoyproxy/envoy#2715`) that
  was causing silent stalls on docker auth retries.
- Verified by running `docker login registry.pospiech.dev -u zocimek`
  successfully several times in a row from a fresh client.

## Test plan

- [ ] Envoy Gateway upgraded to v1.8.0
- [ ] `docker login registry.pospiech.dev -u zocimek` succeeds reliably
- [ ] `docker pull registry.pospiech.dev/gh-runners/poetica:rolling` succeeds from a runner pod
- [ ] After merge: Flux reconciles `poetica-amd64` HR, runner pods spawn cleanly, jobs run end-to-end