### PR TITLE
fix(actions-runner): run poetica-amd64 on the upstream base image

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/poetica-amd64/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/poetica-amd64/helmrelease.yaml
@@ -56,7 +56,26 @@ spec:
                 name: docker-storage
         containers:
           - name: runner
-            image: registry.pospiech.dev/gh-runners/poetica:rolling@sha256:0eabea4761c20970916b8266a968a0c2975c024a746c4ffb8d4b8b1502f3fbcf
+            # TEMPORARY: the upstream base image, not the custom
+            # `gh-runners/poetica` build.
+            #
+            # The custom image bakes in Flutter, the Android SDK, Node and
+            # Playwright, which makes it large enough that pushing it to
+            # registry.pospiech.dev exceeds the Cloudflare proxy's max body
+            # size — so it cannot currently be rebuilt. The pinned digest
+            # below stopped starting, which left this scale set with no
+            # listener and every `runs-on: poetica-amd64` job queued
+            # indefinitely.
+            #
+            # This is the exact image `inzosoft-amd64` and `poetica-copilot`
+            # already run here, so it is known good on this cluster. It
+            # restores the pool for every workflow that only needs Docker
+            # (build-frontend, build-backend, security-scan,
+            # check-contract-drift). It does NOT carry the baked toolchain,
+            # so `[test] mobile` and `e2e-live` stay broken until the custom
+            # image is republished to a registry without the body-size limit
+            # and this pin is pointed back at it.
+            image: ghcr.io/home-operations/actions-runner:2.336.0@sha256:281a9a090522fafbf4967f158b8c97d03552b1978b688893c5f7cb1944bc5fe5
             command:
               - "/home/runner/run.sh"
             env:
@@ -64,8 +83,11 @@ spec:
                 value: "false"
               - name: DOCKER_HOST
                 value: "unix:///var/run/docker.sock"
+              # 120s to match the two scale sets already running this image.
+              # The old 20s was tuned for the custom build, which started
+              # dockerd faster than the stock image does.
               - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
-                value: "20"
+                value: "120"
               - name: NODE
                 valueFrom:
                   fieldRef:


### PR DESCRIPTION
Restores the `poetica-amd64` runner pool, which has been down since **2026-08-10 15:32 UTC**. Every `runs-on: poetica-amd64` job in `Poetica-pl/poetica` has queued indefinitely since then — at peak, 29 runs backed up.

## Diagnosis

`poetica-amd64` was the only scale set on this cluster pinned to the custom `registry.pospiech.dev/gh-runners/poetica` image. That digest stopped starting, and the scale set ended up with **no listener pod at all**:

```
poetica-amd64     0  4  CURRENT=3  RUNNING=3     <- stale status, no listener
poetica-copilot   0  4                            <- listener Running
inzosoft-amd64    0  4                            <- listener Running
home-ops-runner   1  3  CURRENT=1                 <- listener Running
```

Without a listener the scale set never receives job assignments from the broker, so jobs sit in `queued` forever rather than failing — which is why this looked like a general CI outage rather than one broken pool. The HelmRelease itself reports `Ready=True / InstallSucceeded` on chart 0.14.2, so nothing surfaced as unhealthy.

The label split is what gave it away: everything stuck was `poetica-amd64`, everything still running was `poetica-copilot`.

## Why not just rebuild the image

The custom image bakes in Flutter, the Android SDK, Node and Playwright browsers. It is large enough that pushing it to `registry.pospiech.dev` exceeds the Cloudflare proxy's max body size, so it cannot currently be republished.

There is also a bootstrap deadlock: `build-gh-runner.yaml` is itself `runs-on: poetica-amd64`, so the workflow that rebuilds the runner image needs the pool that is down.

## The change

Point the pin at `ghcr.io/home-operations/actions-runner:2.336.0` — the exact image `inzosoft-amd64` and `poetica-copilot` already run here, so it is known good on this cluster and needs no build. After this, `poetica-amd64` is byte-identical to `inzosoft-amd64` apart from its name, org URL and secret.

The docker wait moves 20s to 120s to match the two scale sets already on this image; the old value was tuned for the custom build, which started dockerd faster than the stock image.

## What this fixes, and what it does not

Restored — these need only Docker and buildx:

- `[build] frontend`, `[build] backend`
- `[security] Code Security Scan`
- `[validate] Contract drift`, `[validate] OpenAPI spec`

Still broken until the custom image is republished:

- `[test] mobile` — `mobile-ci.yml` states outright that the SDK, osv-scanner and Node come from the image, and deliberately skips `subosito/flutter-action`
- `e2e-live.yaml` — relies on the preloaded Playwright browsers

## Follow-up

With the pool back, `build-gh-runner.yaml` can run again. The custom image should then be published to **ghcr.io** rather than `registry.pospiech.dev`, which removes the Cloudflare body-size limit entirely, and this pin pointed back at it. That is a separate PR in the poetica repo plus a one-line change here.
