### PR TITLE
feat(actions-runner): pull the poetica-amd64 image from GHCR

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/poetica-amd64/externalsecret-ghcr.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/poetica-amd64/externalsecret-ghcr.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+#
+# Image-pull credentials for the private GHCR package that holds the custom
+# runner image (ghcr.io/poetica-pl/gh-runners/poetica).
+#
+# Scoped to this runner rather than added to components/registry-creds: that
+# component is wired into the `default` and `download` namespaces, and this
+# credential is only ever needed by the poetica-amd64 runner pods.
+#
+# Mirrors the gitea/zot entries in components/registry-creds — same
+# `registry-credentials` 1Password item, a new GHCR_CONFIG field holding a
+# dockerconfigjson for ghcr.io.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &secretName poetica-amd64-ghcr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *secretName
+    template:
+      engineVersion: v2
+      data:
+        .dockerconfigjson: "{{.GHCR_CONFIG}}"
+      type: kubernetes.io/dockerconfigjson
+  dataFrom:
+    - extract:
+        key: registry-credentials

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/poetica-amd64/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/poetica-amd64/helmrelease.yaml
@@ -28,6 +28,8 @@ spec:
       namespace: actions-runner-system
     template:
       spec:
+        imagePullSecrets:
+          - name: poetica-amd64-ghcr
         securityContext:
           supplementalGroups:
             - 123
@@ -56,26 +58,18 @@ spec:
                 name: docker-storage
         containers:
           - name: runner
-            # TEMPORARY: the upstream base image, not the custom
-            # `gh-runners/poetica` build.
+            # Custom Poetica runner image: the upstream base plus Flutter, the
+            # Android SDK, Node and Playwright, so mobile-ci.yml and
+            # e2e-live.yaml do not reinstall them per job.
             #
-            # The custom image bakes in Flutter, the Android SDK, Node and
-            # Playwright, which makes it large enough that pushing it to
-            # registry.pospiech.dev exceeds the Cloudflare proxy's max body
-            # size — so it cannot currently be rebuilt. The pinned digest
-            # below stopped starting, which left this scale set with no
-            # listener and every `runs-on: poetica-amd64` job queued
-            # indefinitely.
+            # Published to GHCR rather than registry.pospiech.dev, whose
+            # Cloudflare proxy caps request bodies below this image's size —
+            # pushes failed there, which is how the previous pin went stale,
+            # stopped starting, and left this scale set without a listener.
             #
-            # This is the exact image `inzosoft-amd64` and `poetica-copilot`
-            # already run here, so it is known good on this cluster. It
-            # restores the pool for every workflow that only needs Docker
-            # (build-frontend, build-backend, security-scan,
-            # check-contract-drift). It does NOT carry the baked toolchain,
-            # so `[test] mobile` and `e2e-live` stay broken until the custom
-            # image is republished to a registry without the body-size limit
-            # and this pin is pointed back at it.
-            image: ghcr.io/home-operations/actions-runner:2.336.0@sha256:281a9a090522fafbf4967f158b8c97d03552b1978b688893c5f7cb1944bc5fe5
+            # The package is PRIVATE, so the pod needs the imagePullSecret
+            # declared below; there is no anonymous pull for it.
+            image: ghcr.io/poetica-pl/gh-runners/poetica:rolling@sha256:b325e6d18d2f3eeeadbb570f4c203e177e6e47f0c1bd823373c203435a07ecd2
             command:
               - "/home/runner/run.sh"
             env:

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/poetica-amd64/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/poetica-amd64/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-ghcr.yaml
   - ./helmrelease.yaml
   - ./rbac.yaml


### PR DESCRIPTION
Final step of restoring the `poetica-amd64` runner pool. Replaces the temporary upstream-base pin from #810 with the custom image, now published to GHCR.

## Sequence recap

1. **#810** — pointed the pool at the upstream base image so it could run at all, breaking the deadlock where the workflow that rebuilds the runner needed the runner it rebuilds.
2. **Poetica-pl/poetica#1371** — moved the image build from `registry.pospiech.dev` to GHCR, whose registry has no body-size cap. The build ran green: `Login to GHCR` and `Build and push` both succeeded, and cosign signed and verified the result.
3. **This PR** — repin to the GHCR digest and wire up the pull secret.

## The change

Image is now:

```
ghcr.io/poetica-pl/gh-runners/poetica:rolling@sha256:b325e6d18d2f3eeeadbb570f4c203e177e6e47f0c1bd823373c203435a07ecd2
```

That digest is the manifest list the build pushed, taken from the run log and confirmed against both the cosign sign and verify steps.

The GHCR package is **private**, and an anonymous manifest fetch returns `403`, so the pod needs credentials — there is no imagePullSecret anywhere in `actions-runner-system` today. This adds:

- `externalsecret-ghcr.yaml` — a `kubernetes.io/dockerconfigjson` secret named `poetica-amd64-ghcr`, sourced from the same `registry-credentials` 1Password item the gitea and zot creds already use, via a new `GHCR_CONFIG` field
- `imagePullSecrets: [poetica-amd64-ghcr]` on the runner pod template

Scoped to this runner rather than added to `components/registry-creds`: that component is wired into the `default` and `download` namespaces, which have no need for this credential.

## ACTION REQUIRED BEFORE MERGE

The 1Password item **`registry-credentials`** needs a new field **`GHCR_CONFIG`** holding a docker config JSON for ghcr.io:

```json
{"auths":{"ghcr.io":{"auth":"<base64 of USERNAME:TOKEN>"}}}
```

where `TOKEN` is a PAT with **`read:packages`** only. Generate the `auth` value with:

```bash
printf '%s:%s' "<github-username>" "<token>" | base64
```

If this field is missing when Flux reconciles, the ExternalSecret will not materialise and the runner pods will sit in `ImagePullBackOff` — the pool would go down again. Add the field first, then merge.

## Verification

- YAML parses for both changed files
- Digest cross-checked against three independent points in the build log (push, cosign sign, cosign verify)
- Existing `poetica-amd64-secret` (the GitHub App credentials) is untouched; this is a second, separate secret

## After merge

Watch for the `poetica-amd64` listener to come back and a runner pod to reach `2/2 Running` on the new image, then confirm `[test] mobile` picks up in the poetica repo.
