### PR TITLE
chore(actions-runner): repin poetica-amd64 to the Flutter 3.44.9 image

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/poetica-amd64/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/poetica-amd64/helmrelease.yaml
@@ -69,7 +69,13 @@ spec:
             #
             # The package is PRIVATE, so the pod needs the imagePullSecret
             # declared below; there is no anonymous pull for it.
-            image: ghcr.io/poetica-pl/gh-runners/poetica:rolling@sha256:b325e6d18d2f3eeeadbb570f4c203e177e6e47f0c1bd823373c203435a07ecd2
+            #
+            # Bakes Flutter 3.44.9 / Dart 3.12.2. The Linux mobile-ci jobs call
+            # `flutter` straight from the image's /opt/flutter with no setup
+            # step, so this digest — not mobile-ci.yml's FLUTTER_VERSION, which
+            # only feeds the macOS jobs — decides the SDK every Linux mobile
+            # job runs against.
+            image: ghcr.io/poetica-pl/gh-runners/poetica:rolling@sha256:2c99de39af42d020d5947f427e1bed72d27bf3e65f3c5820481a6d56332d1a9f
             command:
               - "/home/runner/run.sh"
             env:


### PR DESCRIPTION
Repins the `poetica-amd64` runner scale set to a rebuilt image carrying
**Flutter 3.44.9 / Dart 3.12.2**.

```
- rolling@sha256:b325e6d1…07ecd2   (Flutter 3.41.9)
+ rolling@sha256:2c99de39…d1a9f    (Flutter 3.44.9)
```

## Why this is needed

The Linux `mobile-ci` jobs call `flutter` **directly from the image's
`/opt/flutter`** — there is no `subosito/flutter-action` step on those
jobs. So this digest, not `mobile-ci.yml`'s `FLUTTER_VERSION` (which only
feeds the macOS jobs), is what decides the SDK every Linux mobile job
builds against. Poetica-pl/poetica#1406 raises the app to Flutter 3.44.9
and cannot go green until the runner matches.

## Provenance

Built by the **`[build] gh-runner image`** workflow, run
[31679727133](https://github.com/Poetica-pl/poetica/actions/runs/31679727133),
dispatched against `chore/flutter-upgrade-riverpod3`. That workflow does
not pass `FLUTTER_VERSION` as a build arg — it takes the `ARG` default
from the dockerfile on the checked-out ref, which is why the build had to
run against the app PR's branch rather than `main`.

Image is cosign-signed by the build; verify with:

```
cosign verify --private-infrastructure=true \
  --key env://COSIGN_PUBLIC_KEY \
  ghcr.io/poetica-pl/gh-runners/poetica@sha256:2c99de39af42d020d5947f427e1bed72d27bf3e65f3c5820481a6d56332d1a9f
```

## Why it is safe to land before the app PR

I checked the three ways this could have broken other work, and none
apply:

- **main's SDK constraints already accept it** — `sdk: ^3.11.5` and
  `flutter: ^3.41.0` are both caret ranges, so 3.12.2 / 3.44.9 satisfy
  them. `flutter pub get --enforce-lockfile` on main keeps working.
- **The format gate is changed-files-only.** `mobile-ci.yml` deliberately
  diffs against the merge base rather than running `dart format .`, so
  the newer formatter is applied only to files a change touches — it does
  not retroactively fail the ~395 files that were never format-clean.
- **No other PR is exposed.** #1406 is currently the only open PR
  touching `mobile/`.

The previous digest stopped being pullable once its tag went stale, which
is what left this scale set without a listener before — worth keeping in
mind if a rollback is ever needed: roll back to a digest that still
exists in the package, not to the old tag alone.

## Verification

- [x] `kustomize build` on the `poetica-amd64` overlay succeeds
- [x] New digest appears exactly once; old digest fully gone
- [x] `imagePullSecrets: poetica-amd64-ghcr` still attached (the package
      is private — there is no anonymous pull)
- [ ] After Flux reconciles: confirm the scale set's listener comes back
      and a `poetica-amd64` job picks up
- [ ] Then re-run CI on Poetica-pl/poetica#1406
